### PR TITLE
Fix metadata related to supported platforms.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,14 +8,13 @@ galaxy_info:
     - name: Debian
       versions:
         - jessie
-    - name: Darwin
+    - name: MacOSX
       versions:
         - all
 
   galaxy_tags:
     - development
     - osx
-    - alpine
 
 # dependencies: []
 dependencies:


### PR DESCRIPTION
FYI: https://galaxy.ansible.com/api/v1/platforms/

- This role doesn't support Alpine.
- Now, MacOS is used instead of Darwin.